### PR TITLE
redesign LampOpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,54 @@
 
 
-# LampOpt操作文档
+# LampOpt
 
-#### 概述
+## 概述
 
-LampOpt是一个基于C++的控制台命令解析库，优点是体型小、适应全平台、方便易用。
-
-#### 引用
-
-可选择在IDE中直接在引用目录中添加odt.h，或直接与需编译文件放在同一目录下，并引用：
-`#include "odt.h"`
-
-#### 使用
-
-`odt.h`头文件内定义了一个名为`LampOpt`的`namespace`，其中有以下内容：
-
-```cpp
-struct CommandRead{//用于存储读取成功的参数的结构体
-		std::string CommandName; //参数名称
-		int argvl;//该参数对应的参数值在argv[]中的开始下标
-		int argvr;//该参数对应的参数值在argv[]中的停止下标
-};
+LampOpt是一个超小型参数解析库，允许您进行参数到值的点对点映射。  
+例有以下命令（别名:`-maxret`=`--max_retries`：
+```shell
+my_git -global -maxret=8 -username=cpp -passwd=xxx -dir=./
 ```
-
-和一个函数`std::vector<CommandRead> getopt`，用于读取命令，其原型如下：
-
-```cpp
-std::vector<CommandRead> getopt(int argc,char *argv[],std::vector<std::string>Settings)
+将C++解析得到的内容化为JSON可得：
 ```
-
-返回结果为一个`std::vector<CommandRead>`类型的容器，下标依次列出了每条参数。
-
-参数`argc`与参数`argv[]`为main函数的形参，最后的参数`std::vector<std::string>Settings`为参数的配置文件，其书写规则如下：
-
-1. 从第一个参数开始，分别填写长参数与短参数，如第一个参数填写--help，而第二个参数填写-h时，则--help的长参数将与-h的短参数绑定。
-2. 如果一个参数的长参数与短参数完整，则返回的CommandRead结构体中CommandName将会返回短参数的名称。
-3. 长参数开头应带有--，短参数开头应带有-，而短参数必须带有-，长参数不做要求。
-4. 可以选择不设置长参数或短参数，只需要在该参数位置填写none即可，如果短参数位置填写none，则返回的CommandRead结构体中CommandName将会返回长参数的名称。
-5. 不允许长参数与短参数均填写none的情况存在。
-6. 不允许Settings内元素个数为奇数的情况，这种情况下一定不合法。
-7. 如果有类似tar -xzf的情况出现，返回的数组中将依次返回x、z、f，参数值共享。
-
-如下为简单使用实例可以读取参数并输出读取到的参数与对应参数值：
-
-```cpp
-#include "opt.h"
-#include<iostream>
-#include<vector>
-#include<string>
-using namespace std;
-int main(int argc,char *argv[]){
-	vector<string>str={//参数设置初始化
-		"--test","-t",
-		"--help","-h"
-	};
-	vector<LampOpt::CommandRead>Ret=LampOpt::getopt(argc,argv,str);//接收读取结果
-	for(int i=0;i<Ret.size();i++){
-		cout<<Ret[i].CommandName<<" ";//输出参数名称
-		for(int j=Ret[i].argvl;j<=Ret[i].argvr;j++)//依次枚举参数
-			cout<<argv[j]<<" ";//输出参数值
-		cout<<endl;
-	}
-    return 0;
+{
+  "-global":"true",
+  "--max_retries":"8",
+  "-username":"cpp",
+  "-passwd":"xxx",
+  "-dir":"./"
 }
-``````
+```
+当然是可以配置别名的。
+## 例子
+```cpp
+#include "./opt.h"
+#include <iostream>
+#include <vector>
+#include <map>
+int main(int argc,char** argv){
+  std::vector<std::string> args(argc-1);
+  std::map<std::string,std::string> alias; // aliases
+  alias["--help"]="-h";
+  for(size_t i=1;i<argc;i++) args[i-1] = std::string(argv[i]);
+  LamaOpt::Arguments i(args,alias);
+  std::cout<<i.args["-h"]<<std::endl;
+  return 0;
+}
+```
+```shell
+main -h # main --help
+```
+## 引用
+您可以将其复制到您的项目文件中，然后使用`#include "./opt.h"`来包含头文件。  
 
-#### 报错信息
+## 方法&类
+解析器的实现置于`LampOpt::Arguments`中，是一个类，其中，`LampOpt`是一个`namespace`。  
+对于`LampOpt::Arguments`类，您可以定义它，并由构造函数传入`std::vector<std::string>`来解析参数。  
+在构造函数完成后，您可以访问其中的`args`成员，它保存了由传入参数得出的参数表。  
+对于一个参数，要求其使用 **=** 符号来指定这个参数的值。若不指定的情况，则参数内容默认为`"true"`。  
 
-`Argument setting error`：编程者的参数设置错误，详见上文中的定义要求。
-
-`Unknown argument`：用户的参数输入错误。
+## 重要声明
+This project was under the GPL-2.0 License.  
+Copyright(c) 2022 Lampese.  
+Copyright(c) 2022 nu11ptr.  

--- a/example.cpp
+++ b/example.cpp
@@ -1,0 +1,33 @@
+/*
+This project was under the GPL-2.0 License.
+Copyright(c) 2022 Lampese.
+Copyright(c) 2022 nu11ptr.
+*/
+#include <iostream>
+#include <map>
+#include <vector>
+
+#include "./opt.h"
+
+int main(int argc, char** argv) {
+  std::vector<std::string> args(argc - 1);
+  std::map<std::string, std::string> alias;  // aliases
+  alias["--help"] = "-h";
+  for (size_t i = 1; i < argc; i++) args[i - 1] = std::string(argv[i]);
+  LamaOpt::Arguments arg(args, alias);
+  if (arg.args.empty()) {
+    std::cout << "no arguments given" << std::endl;
+    return 1;
+  }
+  if (arg.args.find("-h") == arg.args.cend()) {
+    std::cout << "unsupported arguments" << std::endl;
+    return 1;
+  }
+  std::cout << "LampOpt test v0.01" << std::endl;
+  std::cout << "Usage:" << std::endl;
+  std::cout << "-h,--help : display this help message." << std::endl;
+  std::cout << "This project was under the GPL-2.0 License." << std::endl;
+  std::cout << "Copyright(c) 2022 Lampese." << std::endl;
+  std::cout << "Copyright(c) 2022 nu11ptr." << std::endl;
+  return 0;
+}

--- a/opt.h
+++ b/opt.h
@@ -1,93 +1,37 @@
-#pragma once
-#include<map>
-#include<string>
-#include<vector>
-#include<cstring>
-#include<exception>
-namespace LampOpt{
-	class Optexception:public std::exception{
-		public:
-			std::string error;
-			Optexception(std::string s){
-				error=s;
-			}
- 			virtual const char* what() const throw(){
-				return error.c_str();
-			}
-	};
-	struct CommandRead{
-		std::string CommandName; 
-		int argvl;
-		int argvr;
-	};
-	std::vector<CommandRead> getopt(int argc,char *argv[],std::vector<std::string>Settings){
-		std::map<std::string,CommandRead>Commands;
-		std::vector<CommandRead>Ret;
-		int SettingsLength=Settings.size();
-		if(SettingsLength%2)throw Optexception("Argument setting error");
-		CommandRead C;
-		for(int i=0;i<SettingsLength;i+=2){
-			if(Settings[i]=="none"&&Settings[i+1]=="none")throw Optexception("Argument setting error");
-			else if(Settings[i+1]!="none"&&Settings[i+1][0]!='-')throw Optexception("Argument setting error");
-			else if(Settings[i]=="none"){
-				C.CommandName=Settings[i+1];
-				Commands[Settings[i+1]]=C;
-			}
-			else if(Settings[i+1]=="none"){
-				C.CommandName=Settings[i];
-				Commands[Settings[i]]=C;
-			}
-			else{
-				C.CommandName=Settings[i+1];
-				Commands[Settings[i]]=C;
-				Commands[Settings[i+1]]=C;
-			}
-		}
-		for(int i=1;i<argc;i++){
-			std::string ThisArgv(argv[i]);
-			if(strlen(argv[i])==1&&argv[i][0]=='-')throw Optexception("Unknown argument:-");
-			else if(argv[i][0]=='-'&&argv[i][1]!='-'){
-				if(Commands.find(ThisArgv)!=Commands.end()){
-					CommandRead ThisCommand=Commands[ThisArgv];
-					ThisCommand.argvl=i+1;
-					int j=i+1;
-					for(;j<argc;j++)if(argv[j][0]=='-')break;
-					ThisCommand.argvr=j-1;
-					i=j-1;
-					Ret.push_back(ThisCommand);
-					continue;
-				}else{
-					int r=i+1;
-					for(;r<argc;r++)if(argv[r][0]=='-')break;
-					for(int j=1;j<strlen(argv[i]);j++){
-						std::string prefix("-");
-						std::string maincommand;
-						maincommand.push_back(argv[i][j]);
-						prefix=prefix+=maincommand;
-						if(Commands.find(prefix)==Commands.end()){
-							throw Optexception("Unknown argument:"+prefix);
-							continue;
-						}else{
-							CommandRead ThisCommand=Commands[prefix];
-							ThisCommand.argvl=i+1;
-							ThisCommand.argvr=r-1;
-							Ret.push_back(ThisCommand);
-						}
-					}
-					i=r-1;
-					continue;
-				}
-			}else if(Commands.find(ThisArgv)!=Commands.end()){
-				CommandRead ThisCommand=Commands[ThisArgv];
-				ThisCommand.argvl=i+1;
-				int j=i+1;
-				for(;j<argc;j++)if(argv[j][0]=='-')break;
-				ThisCommand.argvr=j-1;
-				i=j-1;
-				Ret.push_back(ThisCommand);
-				continue;
-			}else throw Optexception("Unknown argument:"+ThisArgv);
-		}
-		return Ret;
-	}
-}
+/*
+This project was under the GPL-2.0 License.
+Copyright(c) 2022 Lampese.
+Copyright(c) 2022 nu11ptr.
+*/
+#ifndef _LAMAOPT_H_
+#define _LAMAOPT_H_
+#include <map>
+#include <string>
+#include <vector>
+
+namespace LamaOpt {
+typedef struct Arguments {
+  std::map<std::string, std::string> args;
+  Arguments() {}
+  explicit Arguments(const std::vector<std::string>& arg,
+                     const std::map<std::string, std::string>& alias =
+                         std::map<std::string, std::string>()) {
+    for (size_t i = 0; i < arg.size(); i++) {
+      size_t p = arg[i].find_first_of('=');
+      if (p == std::string::npos) {
+        if (alias.find(arg[i]) != alias.cend())
+          args[alias.at(arg[i])] = "true";
+        else
+          args[arg[i]] = "true";
+      } else {
+        std::string&& x = arg[i].substr(0, p - 1);
+        if (alias.find(x) != alias.cend())
+          args[alias.at(x)] = arg[i].substr(p);
+        else
+          args[x] = arg[i].substr(p);
+      }
+    }
+  }
+} Arguments;
+};  // namespace LamaOpt
+#endif


### PR DESCRIPTION
此为对LampOpt的完全重新设计。  
1)砍掉了一些没用的功能。  
2)合理运用C++ STL容器。